### PR TITLE
Remove default configuration value for Launch Script url

### DIFF
--- a/LaunchAdminUi/etc/config.xml
+++ b/LaunchAdminUi/etc/config.xml
@@ -19,7 +19,6 @@
         <launch_general_config>
             <general>
                 <enable>0</enable>
-                <launch_script_url>&lt;script src="//assets.adobedtm.com/your-script-here.js async&gt;&lt;/script&gt;</launch_script_url>
             </general>
         </launch_general_config>
     </default>


### PR DESCRIPTION
### Description
Having default configuration value for Launch Script Url may be confusing for the end user. This Pull Request removes default value and makes field blank on initial configuration.